### PR TITLE
Move VictoriaMetrics data to add-on storage and add backup hooks

### DIFF
--- a/victoria-metrics/DOCS.md
+++ b/victoria-metrics/DOCS.md
@@ -27,7 +27,17 @@ Once the add-on is installed:
 
 ## Data Storage
 
-VictoriaMetrtics Data is stored in folder /share/victoria-metrics-data of Home Assistant OS to make individual backups easy.
+VictoriaMetrics data is stored in the add-on's persistent `/data/victoria-metrics-data` folder. On the first start after upgrading to this version, existing data from `/share/victoria-metrics-data` is copied to `/data/victoria-metrics-data` if it has not already been migrated.
+
+The old `/share/victoria-metrics-data` folder is left in place as a safety copy, but VictoriaMetrics no longer reads from or writes to it. After verifying the add-on is running with the migrated data, you can remove the old folder manually if you want to reclaim space.
+
+If both `/share/victoria-metrics-data` and `/data/victoria-metrics-data` already contain files before migration is marked complete, the add-on refuses to start instead of risking an overwrite. Once migration has been marked complete, the old `/share/victoria-metrics-data` copy may still exist and is ignored. Move or remove one of those copies only if the add-on reports this startup error.
+
+## Backups
+
+Before Home Assistant creates a backup, this add-on runs `vmbackup` inside the VictoriaMetrics container. The backup is written to `/data/victoria-metrics-backup/current`, while the live database files under `/data/victoria-metrics-data` are excluded from the raw add-on backup.
+
+This keeps the database under `/data` during normal operation and gives Home Assistant a consistent VictoriaMetrics backup inside the add-on data folder to include in add-on backups.
 
 ## Configuration
 

--- a/victoria-metrics/DOCS.md
+++ b/victoria-metrics/DOCS.md
@@ -39,6 +39,8 @@ Before Home Assistant creates a backup, this add-on runs `vmbackup` inside the V
 
 This keeps the database under `/data` during normal operation and gives Home Assistant a consistent VictoriaMetrics backup inside the add-on data folder to include in add-on backups.
 
+If `backupToShare` is enabled, the `vmbackup` output is written to `/share/victoria-metrics-backup/current` instead. This can be useful when an external backup system can read the Home Assistant `share` folder but cannot access add-on data.
+
 ## Configuration
 
 ### Retention

--- a/victoria-metrics/Dockerfile
+++ b/victoria-metrics/Dockerfile
@@ -3,23 +3,27 @@ FROM $BUILD_FROM
 
 COPY start-victoria-metrics /
 COPY prometheus.tpl /
-WORKDIR /share/victoria-metrics-data
+WORKDIR /data
 ARG VERSION=v1.144.0
 
 RUN /bin/bash -c 'set -ex && \
     ARCH=$(uname -m) && \
     if [ "$ARCH" == "x86_64" ]; then \
-    wget https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/$VERSION/victoria-metrics-linux-amd64-$VERSION.tar.gz -qO- | tar xvz -C /; \
+    RELEASE_ARCH="amd64"; \
     elif [[ "$ARCH" == "arm"* ]]; then \
-    wget https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/$VERSION/victoria-metrics-linux-arm-$VERSION.tar.gz -qO- | tar xvz -C /; \
+    RELEASE_ARCH="arm"; \
     elif [ "$ARCH" == "aarch64" ]; then \
-    wget https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/$VERSION/victoria-metrics-linux-arm64-$VERSION.tar.gz -qO- | tar xvz -C /; \
+    RELEASE_ARCH="arm64"; \
     else \
     echo "Unsupported architecture $ARCH"; \
-    return -1; \
-    fi'
+    exit 1; \
+    fi && \
+    wget https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/$VERSION/victoria-metrics-linux-$RELEASE_ARCH-$VERSION.tar.gz -qO- | tar xvz -C / && \
+    wget https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/$VERSION/vmutils-linux-$RELEASE_ARCH-$VERSION.tar.gz -qO- | tar xvz -C / vmbackup-prod vmrestore-prod'
 
 RUN chmod a+x /victoria-metrics-prod
+RUN chmod a+x /vmbackup-prod && ln -sf /vmbackup-prod /usr/local/bin/vmbackup
+RUN chmod a+x /vmrestore-prod && ln -sf /vmrestore-prod /usr/local/bin/vmrestore
 RUN chmod a+x /start-victoria-metrics
 
 CMD [ "/start-victoria-metrics"]

--- a/victoria-metrics/config.yaml
+++ b/victoria-metrics/config.yaml
@@ -1,5 +1,5 @@
 name: VictoriaMetrics
-version: "1.148.0-pr83.1"
+version: "1.148.0-pr83.2"
 slug: victoria_metrics
 description: Time Series Database for long term storage as replacement for Prometheus, InfluxDB or Graphite
 webui: "http://[HOST]:[PORT:8428]/"
@@ -22,8 +22,8 @@ init: false
 backup: hot
 backup_pre: /start-victoria-metrics backup
 backup_exclude:
-  - /data/victoria-metrics-data
-  - /data/victoria-metrics-data/**
+  - victoria-metrics-data
+  - victoria-metrics-data/**
 map:
   - share:rw
   - ssl

--- a/victoria-metrics/config.yaml
+++ b/victoria-metrics/config.yaml
@@ -19,6 +19,11 @@ arch:
   - amd64
 #  - i386
 init: false
+backup: hot
+backup_pre: /start-victoria-metrics backup
+backup_exclude:
+  - /data/victoria-metrics-data
+  - /data/victoria-metrics-data/**
 map:
   - share:rw
   - ssl

--- a/victoria-metrics/config.yaml
+++ b/victoria-metrics/config.yaml
@@ -1,5 +1,5 @@
 name: VictoriaMetrics
-version: "1.144.0"
+version: "1.144.1"
 slug: victoria_metrics
 description: Time Series Database for long term storage as replacement for Prometheus, InfluxDB or Graphite
 webui: "http://[HOST]:[PORT:8428]/"
@@ -40,6 +40,7 @@ options:
   prometheusScrapeTimeout: "15s"
   longelivedToken: ""
   homeassistantUrl: ""
+  backupToShare: false
 schema:
   retention: "str?"
   additionalArguments: "str?"
@@ -52,3 +53,4 @@ schema:
   prometheusScrapeTimeout: "str?"
   longelivedToken: "password?"
   homeassistantUrl: "str?"
+  backupToShare: bool

--- a/victoria-metrics/start-victoria-metrics
+++ b/victoria-metrics/start-victoria-metrics
@@ -1,7 +1,62 @@
 #!/usr/bin/with-contenv bashio
 set -e
 
-ARGS="-storageDataPath /share/victoria-metrics-data -retentionPeriod $(bashio::config 'retention')"
+DATA_DIR="/data/victoria-metrics-data"
+LEGACY_DATA_DIR="/share/victoria-metrics-data"
+MIGRATION_MARKER="/data/.victoria-metrics-data-migrated"
+BACKUP_DIR="/data/victoria-metrics-backup/current"
+TMP_BACKUP_DIR="/data/victoria-metrics-backup/.current.tmp"
+SNAPSHOT_URL="http://127.0.0.1:8428/snapshot/create"
+
+is_non_empty_dir() {
+    [ -d "$1" ] && [ -n "$(find "$1" -mindepth 1 -maxdepth 1 -print -quit)" ]
+}
+
+migrate_legacy_data() {
+    mkdir -p "$DATA_DIR"
+
+    if [ -f "$MIGRATION_MARKER" ]; then
+        return
+    fi
+
+    if is_non_empty_dir "$LEGACY_DATA_DIR"; then
+        if is_non_empty_dir "$DATA_DIR"; then
+            bashio::log.fatal "Both ${LEGACY_DATA_DIR} and ${DATA_DIR} contain data. Refusing to migrate automatically; move or remove one copy before starting."
+            exit 1
+        fi
+
+        bashio::log.info "Migrating VictoriaMetrics data from ${LEGACY_DATA_DIR} to ${DATA_DIR}"
+        cp -a "${LEGACY_DATA_DIR}/." "$DATA_DIR/"
+        bashio::log.info "Migration complete. The legacy copy in ${LEGACY_DATA_DIR} was left in place and is no longer used."
+    fi
+
+    date -u +"%Y-%m-%dT%H:%M:%SZ" > "$MIGRATION_MARKER"
+}
+
+backup_data() {
+    bashio::log.info "Creating VictoriaMetrics backup in ${BACKUP_DIR}"
+    rm -rf "$TMP_BACKUP_DIR"
+    mkdir -p "$TMP_BACKUP_DIR"
+
+    vmbackup \
+        -storageDataPath="$DATA_DIR" \
+        -snapshot.createURL="$SNAPSHOT_URL" \
+        -dst="fs://${TMP_BACKUP_DIR}"
+
+    rm -rf "$BACKUP_DIR"
+    mv "$TMP_BACKUP_DIR" "$BACKUP_DIR"
+    bashio::log.info "VictoriaMetrics backup is ready in ${BACKUP_DIR}"
+}
+
+if [ "${1:-}" = "backup" ]; then
+    backup_data
+    exit 0
+fi
+
+migrate_legacy_data
+cd "$DATA_DIR"
+
+ARGS="-storageDataPath ${DATA_DIR} -retentionPeriod $(bashio::config 'retention')"
 
 if bashio::config.true 'enableHTTPAuth'
 then
@@ -23,6 +78,12 @@ fi
 
 # Get user-defined additional arguments
 USER_ARGS="$(bashio::config 'additionalArguments')"
+
+if [[ "$USER_ARGS" =~ (^|[[:space:]])-storageDataPath($|[=[:space:]]) ]]
+then
+    bashio::log.fatal "Do not set -storageDataPath in additionalArguments; this add-on stores VictoriaMetrics data in ${DATA_DIR}."
+    exit 1
+fi
 
 if ! "/victoria-metrics-prod" $ARGS $USER_ARGS
 then

--- a/victoria-metrics/start-victoria-metrics
+++ b/victoria-metrics/start-victoria-metrics
@@ -4,8 +4,6 @@ set -e
 DATA_DIR="/data/victoria-metrics-data"
 LEGACY_DATA_DIR="/share/victoria-metrics-data"
 MIGRATION_MARKER="/data/.victoria-metrics-data-migrated"
-BACKUP_DIR="/data/victoria-metrics-backup/current"
-TMP_BACKUP_DIR="/data/victoria-metrics-backup/.current.tmp"
 SNAPSHOT_URL="http://127.0.0.1:8428/snapshot/create"
 
 is_non_empty_dir() {
@@ -34,6 +32,14 @@ migrate_legacy_data() {
 }
 
 backup_data() {
+    BACKUP_BASE_DIR="/data/victoria-metrics-backup"
+    if bashio::config.true 'backupToShare'; then
+        BACKUP_BASE_DIR="/share/victoria-metrics-backup"
+    fi
+
+    BACKUP_DIR="${BACKUP_BASE_DIR}/current"
+    TMP_BACKUP_DIR="${BACKUP_BASE_DIR}/.current.tmp"
+
     bashio::log.info "Creating VictoriaMetrics backup in ${BACKUP_DIR}"
     rm -rf "$TMP_BACKUP_DIR"
     mkdir -p "$TMP_BACKUP_DIR"

--- a/victoria-metrics/translations/en.yaml
+++ b/victoria-metrics/translations/en.yaml
@@ -32,6 +32,9 @@ configuration:
   homeassistantUrl:
     name: Home Assistant URL
     description: Home Assistant URL incl. port for Prometheus scrape (example "homeassistant:8123") (has no effect if Prometheus scrape is not enabled).
+  backupToShare:
+    name: Store backups in share
+    description: Store VictoriaMetrics backup exports in `/share/victoria-metrics-backup/current` instead of the add-on data folder, for external backup tools that can access the share folder.
   prometheusScrapeConfig:
     name: Prometheus scrape configuration file
     description: |


### PR DESCRIPTION
Refs #82

## Summary

This PR moves VictoriaMetrics database storage from `/share/victoria-metrics-data` to the add-on persistent data folder at `/data/victoria-metrics-data`.

It also adds Home Assistant backup hooks that create a consistent VictoriaMetrics backup with `vmbackup`, while excluding the live database files from the raw add-on backup.

## Changes

- Migrate existing data from `/share/victoria-metrics-data` to `/data/victoria-metrics-data` on first startup.
- Leave the old `/share` database copy in place as a safety copy.
- Refuse ambiguous first-run migration if both old and new data paths already contain data.
- Start VictoriaMetrics with `-storageDataPath /data/victoria-metrics-data`.
- Install `vmbackup` and `vmrestore` from the matching VictoriaMetrics `vmutils` release.
- Add `backup: hot` and `backup_pre` support.
- Write backup exports to `/data/victoria-metrics-backup/current` by default.
- Exclude `/data/victoria-metrics-data` from raw add-on backups.
- Add `backupToShare` option to write backup exports to `/share/victoria-metrics-backup/current` for external backup tools.
- Document the migration and backup behavior.

## Testing

- Validated startup script syntax with `bash -n`.
- Validated patch whitespace with `git diff --check`.
- Deployed to HAOS test system.
- Verified VictoriaMetrics starts with `/data/victoria-metrics-data`.
- Verified `vmbackup` and `vmrestore` are available in the rebuilt container.
- Verified manual backup hook creates a backup under `/data/victoria-metrics-backup/current`.